### PR TITLE
Label krijgt voorrang op slot element

### DIFF
--- a/docker-compose-release.yml
+++ b/docker-compose-release.yml
@@ -11,5 +11,6 @@ services:
       - NO_PROXY=${no_proxy}
       - GIT_REPO=${git_repo}
       - RELEASE_VERSION=${release_version}
+      - SKIP_WCT_SAUCE_POSTINSTALL_DOWNLOAD=1
     extra_hosts:
       - "repository.milieuinfo.be:${REPOSITORY_FIXED_IP}"

--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "@govflanders/vl-ui-form-structure": "^3.12.3",
     "@govflanders/vl-ui-util": "^3.12.3",
     "vl-ui-body": "^1.0.7",
-    "vl-ui-util": "^5.3.3"
+    "vl-ui-util": "^5.3.5"
   }
 }

--- a/src/vl-checkbox.js
+++ b/src/vl-checkbox.js
@@ -9,8 +9,9 @@ import {vlElement, define} from '/node_modules/vl-ui-core/dist/vl-core.js';
  * @mixesvlElement
  *
  * @property {boolean} data-vl-block - Attribuut wordt gebruikt om ervoor te zorgen dat de checkbox getoond wordt als een block element en bijgevol de breedte van de parent zal aannemen.
- * @property {boolean} data-vl-error - Attribuut wordt gebruikt om aan te duiden dat de checkbox verplicht is.
  * @property {boolean} data-vl-disabled - Attribuut wordt gebruikt om te voorkomen dat de gebruiker de checkbox kan selecteren.
+ * @property {boolean} data-vl-error - Attribuut wordt gebruikt om aan te duiden dat de checkbox verplicht is.
+ * @property {boolean} data-vl-label - Attribuut wordt gebruikt om label te definiëren via een attribuut ter vervanging van een slot element.
  * @property {boolean} data-vl-single - Attribuut wordt gebruikt om alleen een checkbox te tonen zonder label.
  * @property {boolean} data-vl-switch - Attribuut wordt gebruikt om een checkbox variant te genereren met de stijl van een switch.
  *
@@ -133,7 +134,8 @@ export class VlCheckbox extends vlElement(HTMLElement) {
   }
 
   _labelChangedCallback(oldValue, newValue) {
-    this._labelSlotElement.textContent = newValue;
+    this._labelSlotElement.remove();
+    this._labelElement.textContent = newValue;
   }
 
   _valueChangedCallback(oldValue, newValue) {

--- a/test/unit/vl-checkbox.test.html
+++ b/test/unit/vl-checkbox.test.html
@@ -32,6 +32,9 @@
       <vl-checkbox data-vl-label="optie 1">
         <span>slot optie 1</span>
       </vl-checkbox>
+      <vl-checkbox>
+        <span>slot optie 1</span>
+      </vl-checkbox>
     </template>
   </test-fixture>
 
@@ -221,17 +224,18 @@
         checkbox._inputElement.click();
       });
 
-      test('label kan via attribuut en slot gedefinieerd worden', () => {
+      test('label kan via attribuut of slot gedefinieerd worden', () => {
         const checkboxes = fixture('vl-checkboxes-slot-fixture');
         assert.equal(checkboxes[0]._labelElement.innerText, checkboxes[0].getAttribute('label'));
-        assert.equal(checkboxes[1]._labelElement.querySelector('slot').assignedElements()[0], checkboxes[1].children[0]);
+        assert.equal(checkboxes[1]._labelElement.innerText, checkboxes[1].getAttribute('label'));
+        assert.equal(checkboxes[2]._labelElement.querySelector('slot').assignedElements()[0], checkboxes[2].children[0]);
       });
 
-      test('het label slot element krijgt voorrang op het label attribuut', () => {
+      test('het label attribuut krijgt voorrang op het slot element', () => {
         const checkboxes = fixture('vl-checkboxes-slot-fixture');
         assert.equal(checkboxes[0]._labelElement.innerText, checkboxes[0].getAttribute('label'));
-        assert.notEqual(checkboxes[1]._labelElement.innerText, checkboxes[1].getAttribute('label'));
-        assert.notEqual(checkboxes[1]._labelElement.innerText, checkboxes[1].querySelector('span').innerText);
+        assert.equal(checkboxes[1]._labelElement.innerText, checkboxes[1].getAttribute('label'));
+        assert.notEqual(checkboxes[1]._labelElement.innerText, checkboxes[2].querySelector('span').innerText);
       });
 
       test('de checked waarde kan programmatisch gezet worden', () => {


### PR DESCRIPTION
Naar aanleiding van #107 is het logischer dat het label voorrang krijgt op het slot element. Het is niet aan te raden om beide te gebruiken, maar als het toch gebeurt zal steeds het attribuut label getoond worden en kan er geen verwarring optreden wanneer het slot element leeg zou zijn.